### PR TITLE
GCI-1333 - Add filing_history_cost to filing history documents

### DIFF
--- a/src/main/java/uk/gov/companieshouse/certifiedcopies/orders/api/model/FilingHistoryDocument.java
+++ b/src/main/java/uk/gov/companieshouse/certifiedcopies/orders/api/model/FilingHistoryDocument.java
@@ -30,6 +30,8 @@ public class FilingHistoryDocument {
 
     private String filingHistoryType;
 
+    private String filingHistoryCost;
+
     public String getFilingHistoryDate() {
         return filingHistoryDate;
     }
@@ -68,6 +70,14 @@ public class FilingHistoryDocument {
 
     public void setFilingHistoryType(String filingHistoryType) {
         this.filingHistoryType = filingHistoryType;
+    }
+
+    public String getFilingHistoryCost() {
+        return filingHistoryCost;
+    }
+
+    public void setFilingHistoryCost(String filingHistoryCost) {
+        this.filingHistoryCost = filingHistoryCost;
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/certifiedcopies/orders/api/service/CertifiedCopyCostCalculatorService.java
+++ b/src/main/java/uk/gov/companieshouse/certifiedcopies/orders/api/service/CertifiedCopyCostCalculatorService.java
@@ -26,8 +26,13 @@ public class CertifiedCopyCostCalculatorService {
                                                        final List<FilingHistoryDocument> filingHistoryDocs) {
         List<ItemCostCalculation> costCalculationList = new ArrayList<>();
         for (FilingHistoryDocument filingHistoryDocument : filingHistoryDocs) {
-            costCalculationList.add(calculateCosts(quantity, deliveryTimescale,
-                                                        filingHistoryDocument.getFilingHistoryType()));
+
+            ItemCostCalculation calculatedCost = calculateCosts(quantity, deliveryTimescale,
+                filingHistoryDocument.getFilingHistoryType());
+
+            filingHistoryDocument.setFilingHistoryCost(calculatedCost.getTotalItemCost());
+
+            costCalculationList.add(calculatedCost);
         }
 
         return costCalculationList;


### PR DESCRIPTION
Add filing_history_cost to filing history documents so that it can be accessed when reaching the `Check your order` screen

Resolves: GCI-1333