### PR TITLE
Remove Spring Data REST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <junit-vintage-engine-version>5.3.2</junit-vintage-engine-version>
         <mockito-junit-jupiter-version>2.18.0</mockito-junit-jupiter-version>
         <hamcrest-all-version>1.3</hamcrest-all-version>
-        <api-security-java.version>0.2.16</api-security-java.version>
+        <api-security-java.version>0.3.0</api-security-java.version>
         <api-helper-java.version>1.4.2</api-helper-java.version>
         <api-sdk-java.version>4.2.36</api-sdk-java.version>
         <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
@@ -58,7 +58,7 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-rest</artifactId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/uk/gov/companieshouse/certifiedcopies/orders/api/repository/CertifiedCopyItemRepository.java
+++ b/src/main/java/uk/gov/companieshouse/certifiedcopies/orders/api/repository/CertifiedCopyItemRepository.java
@@ -1,8 +1,9 @@
 package uk.gov.companieshouse.certifiedcopies.orders.api.repository;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
 import uk.gov.companieshouse.certifiedcopies.orders.api.model.CertifiedCopyItem;
 
-@RepositoryRestResource
+@Repository
 public interface CertifiedCopyItemRepository extends MongoRepository<CertifiedCopyItem, String> { }


### PR DESCRIPTION
Using `@RepositoryRestResource` is generating a separate set of endpoints that we do not want to expose so removing the Spring Data REST dependency and keep just our defined endpoints.
Upgrade `api-security-java.version` to latest version to fix dependency issues caused by transitive dependencies after removing Spring Data REST