### PR TITLE
GCI-2064: Fix security issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <gson.version>2.8.0</gson.version>
         <guava.version>28.1-jre</guava.version>
         <commons.lang.version>2.6</commons.lang.version>
-        <snakeyaml.version>1.25</snakeyaml.version>
+        <snakeyaml.version>1.26</snakeyaml.version>
         <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
         <hamcrest-all-version>1.3</hamcrest-all-version>
         <api-security-java.version>0.3.4</api-security-java.version>


### PR DESCRIPTION
- The only change made to address the [2 alerts](https://github.com/companieshouse/certified-copies.orders.api.ch.gov.uk/security/dependabot) has been to bump the `snakeyaml`  dependency from `1.25` to `1.26`, as originally proposed in the [dependabot PR](https://github.com/companieshouse/certified-copies.orders.api.ch.gov.uk/pull/37) to address the [XML Entity Expansion](https://github.com/companieshouse/certified-copies.orders.api.ch.gov.uk/security/dependabot/2) issue. This was built and tested locally. No adverse efects of the change were detected.
- The other alert relates to a potential issue with using the guava library: [Information Disclosure in Guava](https://github.com/companieshouse/certified-copies.orders.api.ch.gov.uk/security/dependabot/1). This is how that issue is described:

> A temp directory creation vulnerability exists in all Guava versions allowing an attacker with access to the machine to potentially access data in a temporary directory created by the Guava `com.google.common.io.Files.createTempDir()`. The permissions granted to the directory created default to the standard unix-like `/tmp` ones, leaving the files open. We recommend explicitly changing the permissions after the creation of the directory, or removing uses of the vulnerable method.

The only usage of Guava code in the application is of `com.google.common.base.CaseFormat` in `uk.gov.companieshouse.certifiedcopies.orders.api.util.FieldNameConverter`. There is no use of the guava `com.google.common.io.Files` class at all, hence this application is not currently subject to this issue in reality.

As there is no patched version of the Guava library available, no useful changes can currently be made to the app to remove this apparent (but not actual) issue, short of a rewrite of the affected code to no longer use Guava.