### PR TITLE
feature/JU-131: Bump terraform version and add multilb config

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -42,6 +42,15 @@ data "aws_lb_listener" "service_lb_listener" {
   port = 443
 }
 
+data "aws_lb" "secondary_lb" {
+  name = "${var.environment}-chs-apichgovuk-private"
+}
+
+data "aws_lb_listener" "secondary_lb_listener" {
+  load_balancer_arn = data.aws_lb.secondary_lb.arn
+  port = 443
+}
+
 # retrieve all secrets for this stack using the stack path
 data "aws_ssm_parameters_by_path" "secrets" {
   path = "/${local.name_prefix}"

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -93,7 +93,7 @@ module "ecs-service" {
   eric_secrets              = local.eric_secrets
 }
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.235"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.253"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.235"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.258"
 
   # Environmental configuration
   environment             = var.environment
@@ -33,6 +33,17 @@ module "ecs-service" {
   lb_listener_arn                 = data.aws_lb_listener.service_lb_listener.arn
   lb_listener_rule_priority       = local.lb_listener_rule_priority
   lb_listener_paths               = local.lb_listener_paths
+  multilb_setup                   = true
+  multilb_listeners               = {
+    "priv-api-lb": {
+      listener_arn                = data.aws_lb_listener.secondary_lb_listener.arn,
+      load_balancer_arn           = data.aws_lb.secondary_lb.arn
+    }
+    "pub-api-lb": {
+      load_balancer_arn      = data.aws_lb.service_lb.arn
+      listener_arn           = data.aws_lb_listener.service_lb_listener.arn
+    }
+  }
 
   # ECS Task container health check
   use_task_container_healthcheck = true
@@ -64,6 +75,7 @@ module "ecs-service" {
 
   # Cloudwatch
   cloudwatch_alarms_enabled = var.cloudwatch_alarms_enabled
+  multilb_cloudwatch_alarms_enabled = var.multilb_cloudwatch_alarms_enabled
 
   # Service environment variable and secret configs
   task_environment            = local.task_environment

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.258"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.253"
 
   # Environmental configuration
   environment             = var.environment

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -102,6 +102,12 @@ variable "service_scaleup_schedule" {
 variable "cloudwatch_alarms_enabled" {
   description = "Whether to create a standard set of cloudwatch alarms for the service.  Requires an SNS topic to have already been created for the stack."
   type        = bool
+  default     = false
+}
+
+variable "multilb_cloudwatch_alarms_enabled" {
+  description = "Whether to create a standard set of cloudwatch alarms for the service in multilb setup.  Requires an SNS topic to have already been created for the stack."
+  type        = bool
   default     = true
 }
 


### PR DESCRIPTION
We need to bump the ecs module versions as well adding multilb setup for the api.

This has been tested locally using terraform runners to create a plan.
` }

Plan: 26 to add, 0 to change, 0 to destroy.`